### PR TITLE
fix(provenance): include entrypoint in sim cache key

### DIFF
--- a/src/modelops/services/output_manifest.py
+++ b/src/modelops/services/output_manifest.py
@@ -16,6 +16,19 @@ from modelops_contracts.simulation import AggregationTask
 from .provenance_schema import ProvenanceSchema
 
 
+def _get_job_entrypoint(job: SimJob | CalibrationJob) -> str:
+    """Extract entrypoint from job's first task, defaulting to 'default'.
+
+    Note: this returns the entrypoint from the first task only. For jobs
+    with mixed entrypoints (multi-scenario), callers iterating individual
+    tasks should use task.entrypoint directly instead.
+    """
+    tasks = getattr(job, "tasks", None)
+    if tasks and len(tasks) > 0:
+        return str(getattr(tasks[0], "entrypoint", "default"))
+    return "default"
+
+
 @dataclass
 class OutputSpec:
     """Specification for an expected output.
@@ -69,6 +82,7 @@ def generate_output_manifest(job: SimJob, provenance_schema: ProvenanceSchema) -
                 "schema_name": provenance_schema.name,
                 "version": provenance_schema.version,
                 "bundle_digest": bundle_digest,
+                "entrypoint": _get_job_entrypoint(job),
                 "param_id": param_id,
                 "seed": seed,
             }
@@ -125,6 +139,7 @@ def generate_calibration_manifest(
                 "schema_name": provenance_schema.name,
                 "version": provenance_schema.version,
                 "bundle_digest": bundle_digest,
+                "entrypoint": _get_job_entrypoint(job),
                 "param_id": param_id,
                 "seed": seed,
             }

--- a/src/modelops/services/provenance_schema.py
+++ b/src/modelops/services/provenance_schema.py
@@ -39,7 +39,7 @@ class ProvenanceSchema(BaseModel, frozen=True):
     )
 
     sim_path_template: str = Field(
-        default="sims/{bundle_digest[:12]}/{shard(param_id,2,2)}/params_{param_id[:8]}/seed_{seed}",
+        default="sims/{bundle_digest[:12]}/{hash(entrypoint)[:8]}/{shard(param_id,2,2)}/params_{param_id[:8]}/seed_{seed}",
         description="Template for simulation result paths",
     )
 
@@ -154,15 +154,15 @@ class ProvenanceSchema(BaseModel, frozen=True):
 # Pre-defined schema instances for different strategies
 BUNDLE_INVALIDATION_SCHEMA = ProvenanceSchema(
     name="bundle",
-    version=1,
-    sim_path_template="sims/{bundle_digest[:12]}/{shard(param_id,2,2)}/params_{param_id[:8]}/seed_{seed}",
+    version=2,
+    sim_path_template="sims/{bundle_digest[:12]}/{hash(entrypoint)[:8]}/{shard(param_id,2,2)}/params_{param_id[:8]}/seed_{seed}",
     agg_path_template="aggs/{bundle_digest[:12]}/target_{target}/agg_{aggregation_id}",
 )
 
 TOKEN_INVALIDATION_SCHEMA = ProvenanceSchema(
     name="token",
-    version=1,
-    sim_path_template="sims/{model_digest[:12]}/{shard(param_id,2,2)}/params_{param_id[:8]}/seed_{seed}",
+    version=2,
+    sim_path_template="sims/{model_digest[:12]}/{hash(entrypoint)[:8]}/{shard(param_id,2,2)}/params_{param_id[:8]}/seed_{seed}",
     agg_path_template="aggs/{model_digest[:12]}/target_{target}/agg_{aggregation_id}",
 )
 

--- a/src/modelops/services/provenance_store.py
+++ b/src/modelops/services/provenance_store.py
@@ -487,6 +487,7 @@ class ProvenanceStore:
 
         context = {
             "bundle_digest": bundle_digest,  # Already a digest, don't hash again!
+            "entrypoint": str(task.entrypoint) if task.entrypoint else "default",
             "param_id": task.params.param_id,
             "seed": task.seed,
         }

--- a/tests/test_provenance_schema.py
+++ b/tests/test_provenance_schema.py
@@ -111,11 +111,12 @@ class TestInvalidationSchemas:
 
         bundle_digest = make_test_digest("bundle123")
         param_id = make_test_digest("params456")
+        entrypoint = "model:Sim/scenario_a"
 
-        path = schema.sim_path(bundle_digest=bundle_digest, param_id=param_id, seed=42)
+        path = schema.sim_path(bundle_digest=bundle_digest, entrypoint=entrypoint, param_id=param_id, seed=42)
 
-        # Should have bundle/v1 prefix
-        assert "bundle/v1/sims" in path
+        # Should have bundle/v2 prefix (v2 includes entrypoint in cache key)
+        assert "bundle/v2/sims" in path
         # Should use bundle digest directly (not double-hashed)
         assert bundle_digest[:12] in path
         # Should have sharded param_id (shard function hashes first)
@@ -124,17 +125,22 @@ class TestInvalidationSchemas:
         # Should have seed
         assert "seed_42" in path
 
+        # Different entrypoints must produce different paths (fix for #27)
+        path_b = schema.sim_path(bundle_digest=bundle_digest, entrypoint="model:Sim/scenario_b", param_id=param_id, seed=42)
+        assert path != path_b, "Different entrypoints must produce different cache paths"
+
     def test_token_invalidation_schema(self):
         """Test TOKEN_INVALIDATION_SCHEMA structure."""
         schema = TOKEN_INVALIDATION_SCHEMA
 
         model_digest = make_test_digest("model789")
         param_id = make_test_digest("params456")
+        entrypoint = "model:Sim/scenario_a"
 
-        path = schema.sim_path(model_digest=model_digest, param_id=param_id, seed=42)
+        path = schema.sim_path(model_digest=model_digest, entrypoint=entrypoint, param_id=param_id, seed=42)
 
-        # Should have token/v1 prefix
-        assert "token/v1/sims" in path
+        # Should have token/v2 prefix (v2 includes entrypoint in cache key)
+        assert "token/v2/sims" in path
         # Should use model digest directly (not double-hashed)
         assert model_digest[:12] in path
         # Should have seed
@@ -149,23 +155,25 @@ class TestInvalidationSchemas:
         """Verify different schemas produce different paths for same inputs."""
         param_id = make_test_digest("params")
         seed = 42
+        entrypoint = "model:Sim/run"
 
         # Bundle schema uses bundle_digest
         bundle_path = BUNDLE_INVALIDATION_SCHEMA.sim_path(
-            bundle_digest="digest1", param_id=param_id, seed=seed
+            bundle_digest="digest1", entrypoint=entrypoint, param_id=param_id, seed=seed
         )
 
         # Token schema uses model_digest
         token_path = TOKEN_INVALIDATION_SCHEMA.sim_path(
             model_digest="digest1",  # Same value but different param name
+            entrypoint=entrypoint,
             param_id=param_id,
             seed=seed,
         )
 
         # Paths should differ due to different schema names
         assert bundle_path != token_path
-        assert "bundle/v1" in bundle_path
-        assert "token/v1" in token_path
+        assert "bundle/v2" in bundle_path
+        assert "token/v2" in token_path
 
 
 class TestAggregationPaths:

--- a/tests/test_provenance_store.py
+++ b/tests/test_provenance_store.py
@@ -381,11 +381,11 @@ class TestFileStructure:
 
         store.put_sim(task, sim_return)
 
-        # Check that bundle/v1/sims structure exists
-        assert (temp_dir / "bundle" / "v1" / "sims").exists()
+        # Check that bundle/v2/sims structure exists (v2 includes entrypoint in cache key)
+        assert (temp_dir / "bundle" / "v2" / "sims").exists()
 
         # Check for sharding directories
-        bundle_dirs = list((temp_dir / "bundle" / "v1" / "sims").iterdir())
+        bundle_dirs = list((temp_dir / "bundle" / "v2" / "sims").iterdir())
         assert len(bundle_dirs) > 0
 
         # Find the metadata.json file


### PR DESCRIPTION
## Summary
- Include `hash(entrypoint)[:8]` in the provenance sim path template so different scenarios produce different cache keys
- Bump schema version from v1 to v2 to bypass stale cached results
- Add `entrypoint` to `_sim_path_context()` in ProvenanceStore
- Add regression test verifying different entrypoints produce different paths

## Context

The provenance cache keyed simulations on `(bundle_digest, param_id, seed)` but omitted the entrypoint/scenario. When multiple jobs with different scenarios (e.g., `baseline` vs `maternalvx_fr10`) shared the same `(param_id, seed)` on the same Dask cluster, the first task to complete was cached and returned for all subsequent tasks regardless of scenario.

This caused 5-27% result contamination in a vaccine scenario analysis pipeline — baseline jobs returned intervention results and vice versa, producing impossible negative vaccine efficacy estimates.

Fixes #27

## Test plan
- [x] All 262 existing tests pass
- [x] New assertion: different entrypoints produce different cache paths
- [x] Schema version bump ensures old v1 cached data is not read
- [ ] Deploy and verify with parallel scenario jobs on shared Dask cluster