### PR TITLE
fix(runner): enable Dask worker-saturation to prevent OOM from tasks

### DIFF
--- a/src/modelops/runners/job_runner.py
+++ b/src/modelops/runners/job_runner.py
@@ -560,7 +560,10 @@ def main():
         scheduler_addr = os.environ.get("DASK_SCHEDULER_ADDRESS", "tcp://dask-scheduler:8786")
         logger.info(f"Connecting to Dask scheduler at {scheduler_addr}")
 
-        client = Client(scheduler_addr)
+        client = Client(
+            scheduler_addr,
+            config={"distributed.scheduler.worker-saturation": 1.0},
+        )
         logger.info(
             f"Connected to Dask cluster with {len(client.scheduler_info()['workers'])} workers"
         )


### PR DESCRIPTION
  ## Summary
  - Set `distributed.scheduler.worker-saturation` to `1.0` on the Dask Client so the scheduler only assigns tasks equal to each worker's thread count

  ## Context

  The OOM kills on large jobs (1,000+ params) are caused by the Dask scheduler pushing **all** submitted tasks onto workers immediately. With 7,000+ tasks and 4 processes per worker, each worker ends up holding data for hundreds of queued tasks in distributed memory — far exceeding its capacity.

  `worker-saturation=1.0` is Dask's native backpressure mechanism. It limits the scheduler to assigning only as many tasks as a worker has execution slots (4 procs x 1 thread = 4 tasks). Remaining tasks queue on the scheduler, which holds only the lightweight task graph — not the actual data.

  This was identified as the Phase 1 fix in the OOM incident doc (`docs/incidents/oom_scaling_issue_breakdown.md`) but was never wired in.

  ### Relationship to #26

  PR #26 proposes runner-level batching as an OOM fix. That approach:
  - Adds complexity (178 lines) to work around a problem Dask already solves natively
  - Still accumulates `all_raw_sim_returns` across batches (unbounded memory growth)
  - Introduces idle gaps between batches where workers sit waiting
  - Uses an arbitrary batch size (200) unrelated to actual worker capacity

  This one-line fix addresses the root cause at the scheduler level. If OOM persists after this, the next step is addressing the second `gather()` pass that pulls all SimReturns to the runner for Parquet writing.

  ## Test plan
  - [ ] Deploy and run a 1,000+ param job on shared Dask cluster
  - [ ] Verify no OOM kills on workers
  - [ ] Monitor Dask dashboard to confirm task queuing behavior

  Refs #25, #26