### PR TITLE
fix(runner): use dask.config.set() for worker-saturation (fixes #29 crash)

### DIFF
--- a/src/modelops/runners/job_runner.py
+++ b/src/modelops/runners/job_runner.py
@@ -560,10 +560,9 @@ def main():
         scheduler_addr = os.environ.get("DASK_SCHEDULER_ADDRESS", "tcp://dask-scheduler:8786")
         logger.info(f"Connecting to Dask scheduler at {scheduler_addr}")
 
-        client = Client(
-            scheduler_addr,
-            config={"distributed.scheduler.worker-saturation": 1.0},
-        )
+        import dask
+        dask.config.set({"distributed.scheduler.worker-saturation": 1.0})
+        client = Client(scheduler_addr)
         logger.info(
             f"Connected to Dask cluster with {len(client.scheduler_info()['workers'])} workers"
         )


### PR DESCRIPTION
## Summary
- Replace `Client(config=...)` with `dask.config.set()` before `Client()` creation

## Context
PR #29 used `Client(config={"distributed.scheduler.worker-saturation": 1.0})` but this keyword argument doesn't exist in any released version of dask.distributed (including 2024.10.0 which is pinned). All scenario runner pods crash immediately with:

```
ValueError: Unexpected keyword arguments: ['config']
```

`dask.config.set()` is the correct API and works across all Dask versions.

## Test plan
- [x] 262 tests pass with dask==2024.10.0
- [x] Verified `dask.config.set()` correctly sets the config value
- [ ] Deploy and verify scenario jobs run successfully